### PR TITLE
fix(slack): Fix multi-scope categorization, filter merge commits, upgrade to Block Kit

### DIFF
--- a/.github/workflows/release-notification.yml
+++ b/.github/workflows/release-notification.yml
@@ -26,3 +26,4 @@ jobs:
           slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
           slack-channel-id: ${{ secrets.SLACK_CHANNEL }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          sort-commits: true

--- a/dist/handlePROpened.d.ts
+++ b/dist/handlePROpened.d.ts
@@ -1,3 +1,20 @@
+import { Commit } from "./utils/fetchAllCommits";
+/**
+ * Filters out merge commits that add no value to release notes.
+ */
+export declare function filterMergeCommits(commits: Commit[]): Commit[];
+export interface CommitEntry {
+    text: string;
+    author: string;
+}
+/**
+ * Categorizes commits by scope and type for sorted display.
+ * Each commit is placed under its first (primary) scope only.
+ * Author is stored separately for sorting.
+ */
+export declare function categorizeCommits(commits: Commit[], owner: string, repo: string, githubToSlackMap?: Record<string, string>): Record<string, {
+    [type: string]: CommitEntry[];
+}>;
 /**
  * Handles the event when a pull request is opened.
  * @param slackToken - Slack bot token.

--- a/dist/index.js
+++ b/dist/index.js
@@ -29301,9 +29301,56 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.handlePROpened = void 0;
+exports.handlePROpened = exports.categorizeCommits = exports.filterMergeCommits = void 0;
+const core = __importStar(__nccwpck_require__(2186));
 const github = __importStar(__nccwpck_require__(5438));
 const fetchAllCommits_1 = __nccwpck_require__(2857);
+const buildSlackBlocks_1 = __nccwpck_require__(6529);
+const MERGE_COMMIT_PATTERN = /^Merge (branch '.*'|remote-tracking branch '.*'|pull request #\d+)/;
+/**
+ * Filters out merge commits that add no value to release notes.
+ */
+function filterMergeCommits(commits) {
+    return commits.filter((commit) => {
+        const firstLine = commit.commit.message.split("\n")[0];
+        return !MERGE_COMMIT_PATTERN.test(firstLine);
+    });
+}
+exports.filterMergeCommits = filterMergeCommits;
+/**
+ * Categorizes commits by scope and type for sorted display.
+ * Each commit is placed under its first (primary) scope only.
+ * Author is stored separately for sorting.
+ */
+function categorizeCommits(commits, owner, repo, githubToSlackMap) {
+    return commits.reduce((acc, commit) => {
+        const commitMessage = commit.commit.message.split("\n")[0];
+        const commitSha = commit.sha;
+        const commitUrl = `https://github.com/${owner}/${repo}/commit/${commitSha}`;
+        const githubUser = commit.author?.login || commit.commit.author.name;
+        const slackUserId = githubToSlackMap
+            ? githubToSlackMap[githubUser]
+            : null;
+        const userDisplay = slackUserId ? `<@${slackUserId}>` : `@${githubUser}`;
+        const scopeMatch = commitMessage.match(/^\w+\(([\w,\s]+)\):/);
+        const scopes = scopeMatch
+            ? scopeMatch[1].split(",").map((s) => s.trim())
+            : ["other"];
+        const type = commitMessage.split("(")[0].trim();
+        // Place under first (primary) scope only
+        const primaryScope = scopes[0];
+        const entryText = `• <${commitUrl}|${commitMessage}> by ${userDisplay}`;
+        if (!acc[primaryScope]) {
+            acc[primaryScope] = {};
+        }
+        if (!acc[primaryScope][type]) {
+            acc[primaryScope][type] = [];
+        }
+        acc[primaryScope][type].push({ text: entryText, author: githubUser });
+        return acc;
+    }, {});
+}
+exports.categorizeCommits = categorizeCommits;
 /**
  * Handles the event when a pull request is opened.
  * @param slackToken - Slack bot token.
@@ -29317,27 +29364,27 @@ const fetchAllCommits_1 = __nccwpck_require__(2857);
 async function handlePROpened(slackToken, slackChannelId, githubToken, initialMessageTemplate, commitListMessageTemplate, githubToSlackMap, sortCommits = false) {
     const pr = github.context.payload.pull_request;
     if (!pr) {
-        throw new Error('No pull request found');
+        throw new Error("No pull request found");
     }
     const prTitle = pr.title;
-    const prUrl = pr.html_url || '';
+    const prUrl = pr.html_url || "";
     const branchName = pr.head.ref;
     const targetBranch = pr.base.ref;
     const prNumber = pr.number;
-    const prBody = pr.body || '';
+    const prBody = pr.body || "";
     // Format the initial Slack message
     const initialMessage = initialMessageTemplate
-        .replace('${prUrl}', prUrl)
-        .replace('${prTitle}', prTitle)
-        .replace('${branchName}', branchName)
-        .replace('${targetBranch}', targetBranch)
-        .replace(/\\n/g, '\n');
+        .replace("${prUrl}", prUrl)
+        .replace("${prTitle}", prTitle)
+        .replace("${branchName}", branchName)
+        .replace("${targetBranch}", targetBranch)
+        .replace(/\\n/g, "\n");
     // Send the initial message to Slack
-    const initialMessageResponse = await fetch('https://slack.com/api/chat.postMessage', {
-        method: 'POST',
+    const initialMessageResponse = await fetch("https://slack.com/api/chat.postMessage", {
+        method: "POST",
         headers: {
             Authorization: `Bearer ${slackToken}`,
-            'Content-Type': 'application/json',
+            "Content-Type": "application/json",
         },
         body: JSON.stringify({
             channel: slackChannelId,
@@ -29346,7 +29393,7 @@ async function handlePROpened(slackToken, slackChannelId, githubToken, initialMe
     });
     const initialMessageData = await initialMessageResponse.json();
     if (!initialMessageData.ok) {
-        throw new Error('Failed to send initial Slack message');
+        throw new Error("Failed to send initial Slack message");
     }
     const messageTimestamp = initialMessageData.ts;
     // Update the pull request body with the Slack message timestamp
@@ -29359,54 +29406,63 @@ async function handlePROpened(slackToken, slackChannelId, githubToken, initialMe
     });
     // Fetch all commits for the pull request
     const { owner, repo } = github.context.repo;
-    const commitsData = await (0, fetchAllCommits_1.fetchAllCommits)(owner, repo, prNumber, githubToken);
-    let commitMessages;
+    const allCommits = await (0, fetchAllCommits_1.fetchAllCommits)(owner, repo, prNumber, githubToken);
+    // Filter out merge commits
+    const commitsData = filterMergeCommits(allCommits);
+    // Handle edge case: all commits filtered out
+    if (commitsData.length === 0) {
+        await fetch("https://slack.com/api/chat.postMessage", {
+            method: "POST",
+            headers: {
+                Authorization: `Bearer ${slackToken}`,
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+                channel: slackChannelId,
+                text: "No conventional commits to display.",
+                thread_ts: messageTimestamp,
+            }),
+        });
+        return;
+    }
+    const repoUrl = `https://github.com/${owner}/${repo}`;
+    const changelogUrl = `${repoUrl}/compare/${targetBranch}...${branchName}`;
     if (sortCommits) {
         // Categorize commits by scopes and sort them alphabetically by type
-        const categorizedCommits = commitsData.reduce((acc, commit) => {
-            const commitMessage = commit.commit.message.split('\n')[0];
-            const commitSha = commit.sha;
-            const commitUrl = `https://github.com/${owner}/${repo}/commit/${commitSha}`;
-            const githubUser = commit.author?.login || commit.commit.author.name;
-            const slackUserId = githubToSlackMap
-                ? githubToSlackMap[githubUser]
-                : null;
-            const userDisplay = slackUserId
-                ? `<@${slackUserId}>`
-                : `@${githubUser}`;
-            const commitEntry = `• <${commitUrl}|${commitMessage}> by ${userDisplay}`;
-            const scopeMatch = commitMessage.match(/^\w+\(([\w,]+)\):/);
-            const scopes = scopeMatch ? scopeMatch[1].split(',') : ['other'];
-            const type = commitMessage.split('(')[0].trim();
-            scopes.forEach((scope, index) => {
-                const key = scope.trim();
-                if (!acc[key]) {
-                    acc[key] = {};
-                }
-                if (!acc[key][type]) {
-                    acc[key][type] = [];
-                }
-                if (index === 0) {
-                    acc[key][type].push(commitEntry);
-                }
-            });
-            return acc;
-        }, {});
-        // Format commit messages
-        commitMessages = Object.keys(categorizedCommits)
+        const categorizedCommits = categorizeCommits(commitsData, owner, repo, githubToSlackMap);
+        // Build Block Kit blocks
+        const blocks = (0, buildSlackBlocks_1.buildSortedCommitBlocks)(categorizedCommits, changelogUrl, branchName, targetBranch);
+        // Chunk blocks to respect Slack's limits (50 blocks and ~35KB payload per message)
+        const blockChunks = (0, buildSlackBlocks_1.chunkBlocks)(blocks);
+        // Build a plain-text fallback for notifications
+        const fallbackText = Object.keys(categorizedCommits)
             .sort()
-            .map((scope) => `*${scope.charAt(0).toUpperCase() + scope.slice(1)}*\n` +
-            Object.keys(categorizedCommits[scope])
-                .sort()
-                .map((type) => categorizedCommits[scope][type].sort().join('\n'))
-                .join('\n'))
-            .join('\n\n')
-            .replace(/^\s*$(?:\r\n?|\n)/gm, ''); // Remove empty lines
+            .map((scope) => `${scope.charAt(0).toUpperCase() + scope.slice(1)}: ${Object.values(categorizedCommits[scope]).flat().length} commits`)
+            .join(", ");
+        for (const chunk of blockChunks) {
+            const blockResponse = await fetch("https://slack.com/api/chat.postMessage", {
+                method: "POST",
+                headers: {
+                    Authorization: `Bearer ${slackToken}`,
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify({
+                    channel: slackChannelId,
+                    text: fallbackText,
+                    blocks: chunk,
+                    thread_ts: messageTimestamp,
+                }),
+            });
+            const blockData = await blockResponse.json();
+            if (!blockData.ok) {
+                core.error(`Failed to send block chunk: ${blockData.error}`);
+            }
+        }
     }
     else {
-        commitMessages = commitsData
+        const commitMessages = commitsData
             .map((commit) => {
-            const commitMessage = commit.commit.message.split('\n')[0];
+            const commitMessage = commit.commit.message.split("\n")[0];
             const commitSha = commit.sha;
             const commitUrl = `https://github.com/${owner}/${repo}/commit/${commitSha}`;
             const githubUser = commit.author?.login || commit.commit.author.name;
@@ -29418,66 +29474,64 @@ async function handlePROpened(slackToken, slackChannelId, githubToken, initialMe
                 : `@${githubUser}`;
             return `• <${commitUrl}|${commitMessage}> by ${userDisplay}`;
         })
-            .join('\n');
-    }
-    const repoUrl = `https://github.com/${owner}/${repo}`;
-    // Handle Slack message length limits
-    if (commitMessages.length > 4000) {
-        const commitMessagesArr = [];
-        let chunk = '';
-        const lines = commitMessages.split('\n');
-        for (const line of lines) {
-            if ((chunk + '\n' + line).length > 3800) {
+            .join("\n");
+        // Handle Slack message length limits
+        if (commitMessages.length > 4000) {
+            const commitMessagesArr = [];
+            let chunk = "";
+            const lines = commitMessages.split("\n");
+            for (const line of lines) {
+                if ((chunk + "\n" + line).length > 3800) {
+                    commitMessagesArr.push(chunk.trim());
+                    chunk = line;
+                }
+                else {
+                    chunk += "\n" + line;
+                }
+            }
+            if (chunk) {
                 commitMessagesArr.push(chunk.trim());
-                chunk = line;
             }
-            else {
-                chunk += '\n' + line;
+            for (let i = 0; i < commitMessagesArr.length; i++) {
+                let text = commitMessagesArr[i];
+                if (i === commitMessagesArr.length - 1) {
+                    text = `${text}\n\n<${changelogUrl}|Full Changelog: ${branchName} to ${targetBranch}>`;
+                }
+                await fetch("https://slack.com/api/chat.postMessage", {
+                    method: "POST",
+                    headers: {
+                        Authorization: `Bearer ${slackToken}`,
+                        "Content-Type": "application/json",
+                    },
+                    body: JSON.stringify({
+                        channel: slackChannelId,
+                        text: text,
+                        thread_ts: messageTimestamp,
+                    }),
+                });
             }
         }
-        if (chunk) {
-            commitMessagesArr.push(chunk.trim());
-        }
-        for (let i = 0; i < commitMessagesArr.length; i++) {
-            let text = commitMessagesArr[i];
-            if (i === commitMessagesArr.length - 1) {
-                text = `${text}\n\n<${repoUrl}/compare/${targetBranch}...${branchName}|Full Changelog: ${branchName} to ${targetBranch}>`;
-            }
-            await fetch('https://slack.com/api/chat.postMessage', {
-                method: 'POST',
+        else {
+            const commitListMessage = commitListMessageTemplate
+                .replace("${commitListMessage}", commitMessages)
+                .replace("${changelogUrl}", changelogUrl)
+                .replace("${branchName}", branchName)
+                .replace("${targetBranch}", targetBranch)
+                .replace(/\\n/g, "\n");
+            // Send the commit list message to Slack
+            await fetch("https://slack.com/api/chat.postMessage", {
+                method: "POST",
                 headers: {
                     Authorization: `Bearer ${slackToken}`,
-                    'Content-Type': 'application/json',
+                    "Content-Type": "application/json",
                 },
                 body: JSON.stringify({
                     channel: slackChannelId,
-                    text: text,
+                    text: commitListMessage,
                     thread_ts: messageTimestamp,
                 }),
             });
         }
-    }
-    else {
-        const changelogUrl = `${repoUrl}/compare/${targetBranch}...${branchName}`;
-        const commitListMessage = commitListMessageTemplate
-            .replace('${commitListMessage}', commitMessages)
-            .replace('${changelogUrl}', changelogUrl)
-            .replace('${branchName}', branchName)
-            .replace('${targetBranch}', targetBranch)
-            .replace(/\\n/g, '\n');
-        // Send the commit list message to Slack
-        await fetch('https://slack.com/api/chat.postMessage', {
-            method: 'POST',
-            headers: {
-                Authorization: `Bearer ${slackToken}`,
-                'Content-Type': 'application/json',
-            },
-            body: JSON.stringify({
-                channel: slackChannelId,
-                text: commitListMessage,
-                thread_ts: messageTimestamp,
-            }),
-        });
     }
 }
 exports.handlePROpened = handlePROpened;
@@ -29527,40 +29581,40 @@ const fetchAllCommits_1 = __nccwpck_require__(2857);
 async function handlePRUpdated(slackToken, slackChannelId, githubToken, updateMessageTemplate) {
     const pr = github.context.payload.pull_request;
     if (!pr) {
-        throw new Error('No pull request found');
+        throw new Error("No pull request found");
     }
     // Extract the Slack message timestamp from the pull request body
-    const prBody = pr.body || '';
+    const prBody = pr.body || "";
     const messageTimestampMatch = prBody.match(/Slack message_ts: (\d+\.\d+)/);
     const messageTimestamp = messageTimestampMatch
         ? messageTimestampMatch[1]
         : null;
     if (!messageTimestamp) {
-        throw new Error('No Slack message_ts found in pull request description');
+        throw new Error("No Slack message_ts found in pull request description");
     }
     // Fetch all commits for the pull request
     const { owner, repo } = github.context.repo;
     const commitsData = await (0, fetchAllCommits_1.fetchAllCommits)(owner, repo, pr.number, githubToken);
     const latestCommit = commitsData[commitsData.length - 1];
     if (!latestCommit) {
-        throw new Error('No commits found');
+        throw new Error("No commits found");
     }
     // Extract details of the latest commit
-    const commitMessage = latestCommit.commit.message;
+    const commitMessage = latestCommit.commit.message.split("\n")[0];
     const commitSha = latestCommit.sha;
     const commitUrl = `https://github.com/${owner}/${repo}/commit/${commitSha}`;
     const githubUser = latestCommit.author?.login || latestCommit.commit.author.name;
     // Format the update Slack message
     const updateMessage = updateMessageTemplate
-        .replace('${commitUrl}', commitUrl)
-        .replace('${commitMessage}', commitMessage)
-        .replace('${githubUser}', githubUser);
+        .replace("${commitUrl}", commitUrl)
+        .replace("${commitMessage}", commitMessage)
+        .replace("${githubUser}", githubUser);
     // Send the update message to Slack in the same thread as the initial message
-    const slackResponse = await fetch('https://slack.com/api/chat.postMessage', {
-        method: 'POST',
+    const slackResponse = await fetch("https://slack.com/api/chat.postMessage", {
+        method: "POST",
         headers: {
             Authorization: `Bearer ${slackToken}`,
-            'Content-Type': 'application/json',
+            "Content-Type": "application/json",
         },
         body: JSON.stringify({
             channel: slackChannelId,
@@ -29651,6 +29705,117 @@ async function run() {
     }
 }
 run();
+
+
+/***/ }),
+
+/***/ 6529:
+/***/ ((__unused_webpack_module, exports) => {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.chunkBlocks = exports.buildSortedCommitBlocks = void 0;
+/**
+ * Builds Slack Block Kit blocks from categorized commits.
+ * Each scope gets a header, followed by sections grouped by commit type.
+ * Within each type, commits are sorted by author so the same person's
+ * commits appear together.
+ * A divider separates scopes, and a changelog link is appended at the end.
+ */
+function buildSortedCommitBlocks(categorizedCommits, changelogUrl, branchName, targetBranch) {
+    const blocks = [];
+    const sortedScopes = Object.keys(categorizedCommits).sort();
+    for (let i = 0; i < sortedScopes.length; i++) {
+        const scope = sortedScopes[i];
+        const types = categorizedCommits[scope];
+        // Header for the scope
+        blocks.push({
+            type: "header",
+            text: {
+                type: "plain_text",
+                text: scope.charAt(0).toUpperCase() + scope.slice(1),
+                emoji: true,
+            },
+        });
+        // Section per type group, sorted alphabetically.
+        // Slack section blocks have a 3000-char text limit, so we split into
+        // multiple sections when the content is too long.
+        const MAX_SECTION_LENGTH = 2900;
+        const sortedTypes = Object.keys(types).sort();
+        const lines = [];
+        for (const type of sortedTypes) {
+            lines.push(`*${type}*`);
+            const sorted = [...types[type]].sort((a, b) => a.author.localeCompare(b.author));
+            for (const entry of sorted) {
+                lines.push(entry.text);
+            }
+        }
+        // Split lines into sections that fit within Slack's limit
+        let currentText = "";
+        for (const line of lines) {
+            const candidate = currentText ? currentText + "\n" + line : line;
+            if (candidate.length > MAX_SECTION_LENGTH && currentText) {
+                blocks.push({
+                    type: "section",
+                    text: { type: "mrkdwn", text: currentText },
+                });
+                currentText = line;
+            }
+            else {
+                currentText = candidate;
+            }
+        }
+        if (currentText) {
+            blocks.push({
+                type: "section",
+                text: { type: "mrkdwn", text: currentText },
+            });
+        }
+        // Divider between scopes
+        if (i < sortedScopes.length - 1) {
+            blocks.push({ type: "divider" });
+        }
+    }
+    // Divider before changelog
+    blocks.push({ type: "divider" });
+    // Changelog link
+    blocks.push({
+        type: "section",
+        text: {
+            type: "mrkdwn",
+            text: `<${changelogUrl}|Full Changelog: ${branchName} to ${targetBranch}>`,
+        },
+    });
+    return blocks;
+}
+exports.buildSortedCommitBlocks = buildSortedCommitBlocks;
+/**
+ * Splits a blocks array into chunks that respect both Slack's 50-block-per-message
+ * limit and the ~40KB JSON payload limit. Prefers splitting on divider boundaries
+ * so scopes stay together.
+ */
+function chunkBlocks(blocks, maxBlocks = 48, maxPayloadBytes = 35000) {
+    const chunks = [];
+    let current = [];
+    let currentSize = 0;
+    for (const block of blocks) {
+        const blockSize = JSON.stringify(block).length;
+        if (current.length > 0 &&
+            (current.length >= maxBlocks || currentSize + blockSize > maxPayloadBytes)) {
+            chunks.push(current);
+            current = [];
+            currentSize = 0;
+        }
+        current.push(block);
+        currentSize += blockSize;
+    }
+    if (current.length > 0) {
+        chunks.push(current);
+    }
+    return chunks;
+}
+exports.chunkBlocks = chunkBlocks;
 
 
 /***/ }),

--- a/dist/utils/buildSlackBlocks.d.ts
+++ b/dist/utils/buildSlackBlocks.d.ts
@@ -1,0 +1,25 @@
+import { CommitEntry } from "../handlePROpened";
+export interface SlackBlock {
+    type: string;
+    text?: {
+        type: string;
+        text: string;
+        emoji?: boolean;
+    };
+}
+/**
+ * Builds Slack Block Kit blocks from categorized commits.
+ * Each scope gets a header, followed by sections grouped by commit type.
+ * Within each type, commits are sorted by author so the same person's
+ * commits appear together.
+ * A divider separates scopes, and a changelog link is appended at the end.
+ */
+export declare function buildSortedCommitBlocks(categorizedCommits: Record<string, {
+    [type: string]: CommitEntry[];
+}>, changelogUrl: string, branchName: string, targetBranch: string): SlackBlock[];
+/**
+ * Splits a blocks array into chunks that respect both Slack's 50-block-per-message
+ * limit and the ~40KB JSON payload limit. Prefers splitting on divider boundaries
+ * so scopes stay together.
+ */
+export declare function chunkBlocks(blocks: SlackBlock[], maxBlocks?: number, maxPayloadBytes?: number): SlackBlock[][];

--- a/src/handlePROpened.ts
+++ b/src/handlePROpened.ts
@@ -1,5 +1,72 @@
-import * as github from '@actions/github';
-import { fetchAllCommits, Commit } from './utils/fetchAllCommits';
+import * as core from "@actions/core";
+import * as github from "@actions/github";
+import { fetchAllCommits, Commit } from "./utils/fetchAllCommits";
+import { buildSortedCommitBlocks, chunkBlocks } from "./utils/buildSlackBlocks";
+
+const MERGE_COMMIT_PATTERN =
+  /^Merge (branch '.*'|remote-tracking branch '.*'|pull request #\d+)/;
+
+/**
+ * Filters out merge commits that add no value to release notes.
+ */
+export function filterMergeCommits(commits: Commit[]): Commit[] {
+  return commits.filter((commit) => {
+    const firstLine = commit.commit.message.split("\n")[0];
+    return !MERGE_COMMIT_PATTERN.test(firstLine);
+  });
+}
+
+export interface CommitEntry {
+  text: string;
+  author: string;
+}
+
+/**
+ * Categorizes commits by scope and type for sorted display.
+ * Each commit is placed under its first (primary) scope only.
+ * Author is stored separately for sorting.
+ */
+export function categorizeCommits(
+  commits: Commit[],
+  owner: string,
+  repo: string,
+  githubToSlackMap?: Record<string, string>,
+): Record<string, { [type: string]: CommitEntry[] }> {
+  return commits.reduce(
+    (acc, commit) => {
+      const commitMessage = commit.commit.message.split("\n")[0];
+      const commitSha = commit.sha;
+      const commitUrl = `https://github.com/${owner}/${repo}/commit/${commitSha}`;
+      const githubUser = commit.author?.login || commit.commit.author.name;
+      const slackUserId = githubToSlackMap
+        ? githubToSlackMap[githubUser]
+        : null;
+      const userDisplay = slackUserId ? `<@${slackUserId}>` : `@${githubUser}`;
+
+      const scopeMatch = commitMessage.match(/^\w+\(([\w,\s]+)\):/);
+      const scopes = scopeMatch
+        ? scopeMatch[1].split(",").map((s) => s.trim())
+        : ["other"];
+      const type = commitMessage.split("(")[0].trim();
+
+      // Place under first (primary) scope only
+      const primaryScope = scopes[0];
+
+      const entryText = `• <${commitUrl}|${commitMessage}> by ${userDisplay}`;
+
+      if (!acc[primaryScope]) {
+        acc[primaryScope] = {};
+      }
+      if (!acc[primaryScope][type]) {
+        acc[primaryScope][type] = [];
+      }
+      acc[primaryScope][type].push({ text: entryText, author: githubUser });
+
+      return acc;
+    },
+    {} as Record<string, { [type: string]: CommitEntry[] }>,
+  );
+}
 
 /**
  * Handles the event when a pull request is opened.
@@ -18,48 +85,48 @@ export async function handlePROpened(
   initialMessageTemplate: string,
   commitListMessageTemplate: string,
   githubToSlackMap?: Record<string, string>,
-  sortCommits: boolean = false
+  sortCommits: boolean = false,
 ) {
   const pr = github.context.payload.pull_request;
   if (!pr) {
-    throw new Error('No pull request found');
+    throw new Error("No pull request found");
   }
 
   const prTitle: string = pr.title;
-  const prUrl: string = pr.html_url || '';
+  const prUrl: string = pr.html_url || "";
   const branchName: string = pr.head.ref;
   const targetBranch: string = pr.base.ref;
   const prNumber: number = pr.number;
-  const prBody: string = pr.body || '';
+  const prBody: string = pr.body || "";
 
   // Format the initial Slack message
   const initialMessage = initialMessageTemplate
-    .replace('${prUrl}', prUrl)
-    .replace('${prTitle}', prTitle)
-    .replace('${branchName}', branchName)
-    .replace('${targetBranch}', targetBranch)
-    .replace(/\\n/g, '\n');
+    .replace("${prUrl}", prUrl)
+    .replace("${prTitle}", prTitle)
+    .replace("${branchName}", branchName)
+    .replace("${targetBranch}", targetBranch)
+    .replace(/\\n/g, "\n");
 
   // Send the initial message to Slack
   const initialMessageResponse = await fetch(
-    'https://slack.com/api/chat.postMessage',
+    "https://slack.com/api/chat.postMessage",
     {
-      method: 'POST',
+      method: "POST",
       headers: {
         Authorization: `Bearer ${slackToken}`,
-        'Content-Type': 'application/json',
+        "Content-Type": "application/json",
       },
       body: JSON.stringify({
         channel: slackChannelId,
         text: initialMessage,
       }),
-    }
+    },
   );
 
   const initialMessageData = await initialMessageResponse.json();
 
   if (!initialMessageData.ok) {
-    throw new Error('Failed to send initial Slack message');
+    throw new Error("Failed to send initial Slack message");
   }
 
   const messageTimestamp = initialMessageData.ts;
@@ -75,62 +142,88 @@ export async function handlePROpened(
 
   // Fetch all commits for the pull request
   const { owner, repo } = github.context.repo;
-  const commitsData = await fetchAllCommits(owner, repo, prNumber, githubToken);
+  const allCommits = await fetchAllCommits(owner, repo, prNumber, githubToken);
 
-  let commitMessages: string;
+  // Filter out merge commits
+  const commitsData = filterMergeCommits(allCommits);
+
+  // Handle edge case: all commits filtered out
+  if (commitsData.length === 0) {
+    await fetch("https://slack.com/api/chat.postMessage", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${slackToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        channel: slackChannelId,
+        text: "No conventional commits to display.",
+        thread_ts: messageTimestamp,
+      }),
+    });
+    return;
+  }
+
+  const repoUrl = `https://github.com/${owner}/${repo}`;
+  const changelogUrl = `${repoUrl}/compare/${targetBranch}...${branchName}`;
+
   if (sortCommits) {
     // Categorize commits by scopes and sort them alphabetically by type
-    const categorizedCommits: Record<string, { [type: string]: string[] }> =
-      commitsData.reduce((acc, commit) => {
-        const commitMessage = commit.commit.message.split('\n')[0];
-        const commitSha = commit.sha;
-        const commitUrl = `https://github.com/${owner}/${repo}/commit/${commitSha}`;
-        const githubUser = commit.author?.login || commit.commit.author.name;
-        const slackUserId = githubToSlackMap
-          ? githubToSlackMap[githubUser]
-          : null;
-        const userDisplay = slackUserId
-          ? `<@${slackUserId}>`
-          : `@${githubUser}`;
-        const commitEntry = `• <${commitUrl}|${commitMessage}> by ${userDisplay}`;
+    const categorizedCommits = categorizeCommits(
+      commitsData,
+      owner,
+      repo,
+      githubToSlackMap,
+    );
 
-        const scopeMatch = commitMessage.match(/^\w+\(([\w,]+)\):/);
-        const scopes = scopeMatch ? scopeMatch[1].split(',') : ['other'];
-        const type = commitMessage.split('(')[0].trim();
+    // Build Block Kit blocks
+    const blocks = buildSortedCommitBlocks(
+      categorizedCommits,
+      changelogUrl,
+      branchName,
+      targetBranch,
+    );
 
-        scopes.forEach((scope, index) => {
-          const key = scope.trim();
-          if (!acc[key]) {
-            acc[key] = {};
-          }
-          if (!acc[key][type]) {
-            acc[key][type] = [];
-          }
-          if (index === 0) {
-            acc[key][type].push(commitEntry);
-          }
-        });
+    // Chunk blocks to respect Slack's limits (50 blocks and ~35KB payload per message)
+    const blockChunks = chunkBlocks(blocks);
 
-        return acc;
-      }, {} as Record<string, { [type: string]: string[] }>);
-
-    // Format commit messages
-    commitMessages = Object.keys(categorizedCommits)
+    // Build a plain-text fallback for notifications
+    const fallbackText = Object.keys(categorizedCommits)
       .sort()
       .map(
         (scope) =>
-          `*${scope.charAt(0).toUpperCase() + scope.slice(1)}*\n` +
-          Object.keys(categorizedCommits[scope])
-            .sort()
-            .map((type) => categorizedCommits[scope][type].sort().join('\n'))
-            .join('\n')
+          `${scope.charAt(0).toUpperCase() + scope.slice(1)}: ${
+            Object.values(categorizedCommits[scope]).flat().length
+          } commits`,
       )
-      .join('\n\n')
-      .replace(/^\s*$(?:\r\n?|\n)/gm, ''); // Remove empty lines
+      .join(", ");
+
+    for (const chunk of blockChunks) {
+      const blockResponse = await fetch(
+        "https://slack.com/api/chat.postMessage",
+        {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${slackToken}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            channel: slackChannelId,
+            text: fallbackText,
+            blocks: chunk,
+            thread_ts: messageTimestamp,
+          }),
+        },
+      );
+      const blockData = await blockResponse.json();
+      if (!blockData.ok) {
+        core.error(`Failed to send block chunk: ${blockData.error}`);
+      }
+    }
   } else {
-    commitMessages = commitsData
+    const commitMessages = commitsData
       .map((commit: Commit) => {
-        const commitMessage = commit.commit.message.split('\n')[0];
+        const commitMessage = commit.commit.message.split("\n")[0];
         const commitSha = commit.sha;
         const commitUrl = `https://github.com/${owner}/${repo}/commit/${commitSha}`;
         const githubUser = commit.author?.login || commit.commit.author.name;
@@ -142,70 +235,67 @@ export async function handlePROpened(
           : `@${githubUser}`;
         return `• <${commitUrl}|${commitMessage}> by ${userDisplay}`;
       })
-      .join('\n');
-  }
+      .join("\n");
 
-  const repoUrl = `https://github.com/${owner}/${repo}`;
-  // Handle Slack message length limits
+    // Handle Slack message length limits
+    if (commitMessages.length > 4000) {
+      const commitMessagesArr = [];
+      let chunk = "";
+      const lines = commitMessages.split("\n");
 
-  if (commitMessages.length > 4000) {
-    const commitMessagesArr = [];
-    let chunk = '';
-    const lines = commitMessages.split('\n');
-
-    for (const line of lines) {
-      if ((chunk + '\n' + line).length > 3800) {
+      for (const line of lines) {
+        if ((chunk + "\n" + line).length > 3800) {
+          commitMessagesArr.push(chunk.trim());
+          chunk = line;
+        } else {
+          chunk += "\n" + line;
+        }
+      }
+      if (chunk) {
         commitMessagesArr.push(chunk.trim());
-        chunk = line;
-      } else {
-        chunk += '\n' + line;
-      }
-    }
-    if (chunk) {
-      commitMessagesArr.push(chunk.trim());
-    }
-
-    for (let i = 0; i < commitMessagesArr.length; i++) {
-      let text = commitMessagesArr[i];
-
-      if (i === commitMessagesArr.length - 1) {
-        text = `${text}\n\n<${repoUrl}/compare/${targetBranch}...${branchName}|Full Changelog: ${branchName} to ${targetBranch}>`;
       }
 
-      await fetch('https://slack.com/api/chat.postMessage', {
-        method: 'POST',
+      for (let i = 0; i < commitMessagesArr.length; i++) {
+        let text = commitMessagesArr[i];
+
+        if (i === commitMessagesArr.length - 1) {
+          text = `${text}\n\n<${changelogUrl}|Full Changelog: ${branchName} to ${targetBranch}>`;
+        }
+
+        await fetch("https://slack.com/api/chat.postMessage", {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${slackToken}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            channel: slackChannelId,
+            text: text,
+            thread_ts: messageTimestamp,
+          }),
+        });
+      }
+    } else {
+      const commitListMessage = commitListMessageTemplate
+        .replace("${commitListMessage}", commitMessages)
+        .replace("${changelogUrl}", changelogUrl)
+        .replace("${branchName}", branchName)
+        .replace("${targetBranch}", targetBranch)
+        .replace(/\\n/g, "\n");
+
+      // Send the commit list message to Slack
+      await fetch("https://slack.com/api/chat.postMessage", {
+        method: "POST",
         headers: {
           Authorization: `Bearer ${slackToken}`,
-          'Content-Type': 'application/json',
+          "Content-Type": "application/json",
         },
         body: JSON.stringify({
           channel: slackChannelId,
-          text: text,
+          text: commitListMessage,
           thread_ts: messageTimestamp,
         }),
       });
     }
-  } else {
-    const changelogUrl = `${repoUrl}/compare/${targetBranch}...${branchName}`;
-    const commitListMessage = commitListMessageTemplate
-      .replace('${commitListMessage}', commitMessages)
-      .replace('${changelogUrl}', changelogUrl)
-      .replace('${branchName}', branchName)
-      .replace('${targetBranch}', targetBranch)
-      .replace(/\\n/g, '\n');
-
-    // Send the commit list message to Slack
-    await fetch('https://slack.com/api/chat.postMessage', {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${slackToken}`,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        channel: slackChannelId,
-        text: commitListMessage,
-        thread_ts: messageTimestamp,
-      }),
-    });
   }
 }

--- a/src/handlePRUpdated.ts
+++ b/src/handlePRUpdated.ts
@@ -1,5 +1,5 @@
-import * as github from '@actions/github';
-import { fetchAllCommits, Commit } from './utils/fetchAllCommits';
+import * as github from "@actions/github";
+import { fetchAllCommits, Commit } from "./utils/fetchAllCommits";
 
 /**
  * Handles the event when a pull request is updated with new commits.
@@ -12,22 +12,22 @@ export async function handlePRUpdated(
   slackToken: string,
   slackChannelId: string,
   githubToken: string,
-  updateMessageTemplate: string
+  updateMessageTemplate: string,
 ) {
   const pr = github.context.payload.pull_request;
   if (!pr) {
-    throw new Error('No pull request found');
+    throw new Error("No pull request found");
   }
 
   // Extract the Slack message timestamp from the pull request body
-  const prBody = pr.body || '';
+  const prBody = pr.body || "";
   const messageTimestampMatch = prBody.match(/Slack message_ts: (\d+\.\d+)/);
   const messageTimestamp = messageTimestampMatch
     ? messageTimestampMatch[1]
     : null;
 
   if (!messageTimestamp) {
-    throw new Error('No Slack message_ts found in pull request description');
+    throw new Error("No Slack message_ts found in pull request description");
   }
 
   // Fetch all commits for the pull request
@@ -36,16 +36,16 @@ export async function handlePRUpdated(
     owner,
     repo,
     pr.number,
-    githubToken
+    githubToken,
   );
   const latestCommit = commitsData[commitsData.length - 1];
 
   if (!latestCommit) {
-    throw new Error('No commits found');
+    throw new Error("No commits found");
   }
 
   // Extract details of the latest commit
-  const commitMessage = latestCommit.commit.message;
+  const commitMessage = latestCommit.commit.message.split("\n")[0];
   const commitSha = latestCommit.sha;
   const commitUrl = `https://github.com/${owner}/${repo}/commit/${commitSha}`;
   const githubUser =
@@ -53,16 +53,16 @@ export async function handlePRUpdated(
 
   // Format the update Slack message
   const updateMessage = updateMessageTemplate
-    .replace('${commitUrl}', commitUrl)
-    .replace('${commitMessage}', commitMessage)
-    .replace('${githubUser}', githubUser);
+    .replace("${commitUrl}", commitUrl)
+    .replace("${commitMessage}", commitMessage)
+    .replace("${githubUser}", githubUser);
 
   // Send the update message to Slack in the same thread as the initial message
-  const slackResponse = await fetch('https://slack.com/api/chat.postMessage', {
-    method: 'POST',
+  const slackResponse = await fetch("https://slack.com/api/chat.postMessage", {
+    method: "POST",
     headers: {
       Authorization: `Bearer ${slackToken}`,
-      'Content-Type': 'application/json',
+      "Content-Type": "application/json",
     },
     body: JSON.stringify({
       channel: slackChannelId,
@@ -76,7 +76,7 @@ export async function handlePRUpdated(
     throw new Error(
       `Slack API request failed: ${slackResponse.status} ${
         slackResponse.statusText
-      } - ${JSON.stringify(errorData)}`
+      } - ${JSON.stringify(errorData)}`,
     );
   }
 }

--- a/src/utils/buildSlackBlocks.ts
+++ b/src/utils/buildSlackBlocks.ts
@@ -1,0 +1,135 @@
+import { CommitEntry } from "../handlePROpened";
+
+export interface SlackBlock {
+  type: string;
+  text?: {
+    type: string;
+    text: string;
+    emoji?: boolean;
+  };
+}
+
+/**
+ * Builds Slack Block Kit blocks from categorized commits.
+ * Each scope gets a header, followed by sections grouped by commit type.
+ * Within each type, commits are sorted by author so the same person's
+ * commits appear together.
+ * A divider separates scopes, and a changelog link is appended at the end.
+ */
+export function buildSortedCommitBlocks(
+  categorizedCommits: Record<string, { [type: string]: CommitEntry[] }>,
+  changelogUrl: string,
+  branchName: string,
+  targetBranch: string,
+): SlackBlock[] {
+  const blocks: SlackBlock[] = [];
+  const sortedScopes = Object.keys(categorizedCommits).sort();
+
+  for (let i = 0; i < sortedScopes.length; i++) {
+    const scope = sortedScopes[i];
+    const types = categorizedCommits[scope];
+
+    // Header for the scope
+    blocks.push({
+      type: "header",
+      text: {
+        type: "plain_text",
+        text: scope.charAt(0).toUpperCase() + scope.slice(1),
+        emoji: true,
+      },
+    });
+
+    // Section per type group, sorted alphabetically.
+    // Slack section blocks have a 3000-char text limit, so we split into
+    // multiple sections when the content is too long.
+    const MAX_SECTION_LENGTH = 2900;
+    const sortedTypes = Object.keys(types).sort();
+    const lines: string[] = [];
+    for (const type of sortedTypes) {
+      lines.push(`*${type}*`);
+      const sorted = [...types[type]].sort((a, b) =>
+        a.author.localeCompare(b.author),
+      );
+      for (const entry of sorted) {
+        lines.push(entry.text);
+      }
+    }
+
+    // Split lines into sections that fit within Slack's limit
+    let currentText = "";
+    for (const line of lines) {
+      const candidate = currentText ? currentText + "\n" + line : line;
+      if (candidate.length > MAX_SECTION_LENGTH && currentText) {
+        blocks.push({
+          type: "section",
+          text: { type: "mrkdwn", text: currentText },
+        });
+        currentText = line;
+      } else {
+        currentText = candidate;
+      }
+    }
+    if (currentText) {
+      blocks.push({
+        type: "section",
+        text: { type: "mrkdwn", text: currentText },
+      });
+    }
+
+    // Divider between scopes
+    if (i < sortedScopes.length - 1) {
+      blocks.push({ type: "divider" });
+    }
+  }
+
+  // Divider before changelog
+  blocks.push({ type: "divider" });
+
+  // Changelog link
+  blocks.push({
+    type: "section",
+    text: {
+      type: "mrkdwn",
+      text: `<${changelogUrl}|Full Changelog: ${branchName} to ${targetBranch}>`,
+    },
+  });
+
+  return blocks;
+}
+
+/**
+ * Splits a blocks array into chunks that respect both Slack's 50-block-per-message
+ * limit and the ~40KB JSON payload limit. Prefers splitting on divider boundaries
+ * so scopes stay together.
+ */
+export function chunkBlocks(
+  blocks: SlackBlock[],
+  maxBlocks: number = 48,
+  maxPayloadBytes: number = 35000,
+): SlackBlock[][] {
+  const chunks: SlackBlock[][] = [];
+  let current: SlackBlock[] = [];
+  let currentSize = 0;
+
+  for (const block of blocks) {
+    const blockSize = JSON.stringify(block).length;
+
+    if (
+      current.length > 0 &&
+      (current.length >= maxBlocks || currentSize + blockSize > maxPayloadBytes)
+    ) {
+      chunks.push(current);
+      current = [];
+      currentSize = 0;
+    }
+
+    current.push(block);
+    currentSize += blockSize;
+  }
+
+  if (current.length > 0) {
+    chunks.push(current);
+  }
+
+  return chunks;
+}

--- a/tests/buildSlackBlocks.test.ts
+++ b/tests/buildSlackBlocks.test.ts
@@ -1,0 +1,252 @@
+import {
+  buildSortedCommitBlocks,
+  chunkBlocks,
+  SlackBlock,
+} from "../src/utils/buildSlackBlocks";
+import { CommitEntry } from "../src/handlePROpened";
+
+const entry = (text: string, author: string): CommitEntry => ({
+  text,
+  author,
+});
+
+describe("buildSortedCommitBlocks", () => {
+  const changelogUrl = "https://github.com/owner/repo/compare/main...release";
+  const branchName = "release";
+  const targetBranch = "main";
+
+  it("builds blocks with scopes sorted alphabetically", () => {
+    const categorized = {
+      frontend: {
+        fix: [entry("• fix(frontend): Fix button by @user", "user")],
+      },
+      backend: {
+        chore: [entry("• chore(backend): Update deps by @user", "user")],
+      },
+    };
+
+    const blocks = buildSortedCommitBlocks(
+      categorized,
+      changelogUrl,
+      branchName,
+      targetBranch,
+    );
+
+    // Backend comes first alphabetically
+    expect(blocks[0]).toEqual({
+      type: "header",
+      text: { type: "plain_text", text: "Backend", emoji: true },
+    });
+    expect(blocks[1]).toEqual({
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: "*chore*\n• chore(backend): Update deps by @user",
+      },
+    });
+    // Divider between scopes
+    expect(blocks[2]).toEqual({ type: "divider" });
+    // Frontend second
+    expect(blocks[3]).toEqual({
+      type: "header",
+      text: { type: "plain_text", text: "Frontend", emoji: true },
+    });
+    expect(blocks[4]).toEqual({
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: "*fix*\n• fix(frontend): Fix button by @user",
+      },
+    });
+    // Divider before changelog
+    expect(blocks[5]).toEqual({ type: "divider" });
+    // Changelog link
+    expect(blocks[6]).toEqual({
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: `<${changelogUrl}|Full Changelog: ${branchName} to ${targetBranch}>`,
+      },
+    });
+    expect(blocks).toHaveLength(7);
+  });
+
+  it("sorts types within a scope alphabetically", () => {
+    const categorized = {
+      backend: {
+        fix: [entry("• fix(backend): Fix auth by @user", "user")],
+        chore: [entry("• chore(backend): Update deps by @user", "user")],
+        feat: [entry("• feat(backend): Add endpoint by @user", "user")],
+      },
+    };
+
+    const blocks = buildSortedCommitBlocks(
+      categorized,
+      changelogUrl,
+      branchName,
+      targetBranch,
+    );
+
+    // Single scope: header + section + divider + changelog = 4 blocks
+    expect(blocks).toHaveLength(4);
+    const sectionText = blocks[1].text!.text;
+    const typeOrder = sectionText
+      .split("\n")
+      .filter((l: string) => l.startsWith("*"))
+      .map((l: string) => l.replace(/\*/g, ""));
+    expect(typeOrder).toEqual(["chore", "feat", "fix"]);
+  });
+
+  it("sorts commits by author within each type", () => {
+    const categorized = {
+      backend: {
+        fix: [
+          entry("• fix: C commit by @zara", "zara"),
+          entry("• fix: A commit by @alice", "alice"),
+          entry("• fix: B commit by @bob", "bob"),
+        ],
+      },
+    };
+
+    const blocks = buildSortedCommitBlocks(
+      categorized,
+      changelogUrl,
+      branchName,
+      targetBranch,
+    );
+
+    const sectionText = blocks[1].text!.text;
+    const commitLines = sectionText
+      .split("\n")
+      .filter((l: string) => l.startsWith("•"));
+    expect(commitLines[0]).toContain("@alice");
+    expect(commitLines[1]).toContain("@bob");
+    expect(commitLines[2]).toContain("@zara");
+  });
+
+  it("groups same author's commits together", () => {
+    const categorized = {
+      frontend: {
+        fix: [
+          entry("• fix: First by @bob", "bob"),
+          entry("• fix: Second by @alice", "alice"),
+          entry("• fix: Third by @alice", "alice"),
+          entry("• fix: Fourth by @bob", "bob"),
+        ],
+      },
+    };
+
+    const blocks = buildSortedCommitBlocks(
+      categorized,
+      changelogUrl,
+      branchName,
+      targetBranch,
+    );
+
+    const sectionText = blocks[1].text!.text;
+    const commitLines = sectionText
+      .split("\n")
+      .filter((l: string) => l.startsWith("•"));
+    // alice's commits first, then bob's
+    expect(commitLines[0]).toContain("@alice");
+    expect(commitLines[1]).toContain("@alice");
+    expect(commitLines[2]).toContain("@bob");
+    expect(commitLines[3]).toContain("@bob");
+  });
+
+  it("splits large scopes into multiple section blocks under 3000 chars", () => {
+    // Generate enough commits to exceed the 2900-char section limit
+    const longEntries: CommitEntry[] = Array.from({ length: 30 }, (_, i) =>
+      entry(
+        `• fix(backend): Fix issue number ${i} with a reasonably long commit message to inflate size <https://github.com/owner/repo/commit/abc${i}|link> by @developer${i}`,
+        `developer${i}`,
+      ),
+    );
+
+    const categorized = {
+      backend: { fix: longEntries },
+    };
+
+    const blocks = buildSortedCommitBlocks(
+      categorized,
+      changelogUrl,
+      branchName,
+      targetBranch,
+    );
+
+    // Should have: header + multiple sections + divider + changelog
+    const sectionBlocks = blocks.filter(
+      (b) => b.type === "section" && !b.text?.text.includes("Full Changelog"),
+    );
+    expect(sectionBlocks.length).toBeGreaterThan(1);
+
+    // Each section should be under 3000 chars
+    for (const section of sectionBlocks) {
+      expect(section.text!.text.length).toBeLessThanOrEqual(3000);
+    }
+
+    // All commits should still be present across all sections
+    const allText = sectionBlocks.map((b) => b.text!.text).join("\n");
+    for (let i = 0; i < 30; i++) {
+      expect(allText).toContain(`Fix issue number ${i}`);
+    }
+  });
+
+  it("handles a single scope without inter-scope divider", () => {
+    const categorized = {
+      other: {
+        chore: [entry("• chore: Misc task by @user", "user")],
+      },
+    };
+
+    const blocks = buildSortedCommitBlocks(
+      categorized,
+      changelogUrl,
+      branchName,
+      targetBranch,
+    );
+
+    // header + section + divider(changelog) + changelog = 4
+    expect(blocks).toHaveLength(4);
+    expect(blocks[0].type).toBe("header");
+    expect(blocks[1].type).toBe("section");
+    expect(blocks[2].type).toBe("divider");
+    expect(blocks[3].type).toBe("section"); // changelog
+  });
+});
+
+describe("chunkBlocks", () => {
+  const makeBlocks = (n: number): SlackBlock[] =>
+    Array.from({ length: n }, (_, i) => ({
+      type: "section",
+      text: { type: "mrkdwn", text: `block ${i}` },
+    }));
+
+  it("returns a single chunk when blocks fit within limit", () => {
+    const blocks = makeBlocks(10);
+    const chunks = chunkBlocks(blocks, 48);
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0]).toEqual(blocks);
+  });
+
+  it("splits blocks into multiple chunks when exceeding limit", () => {
+    const blocks = makeBlocks(100);
+    const chunks = chunkBlocks(blocks, 48);
+    expect(chunks).toHaveLength(3); // 48 + 48 + 4
+    expect(chunks[0]).toHaveLength(48);
+    expect(chunks[1]).toHaveLength(48);
+    expect(chunks[2]).toHaveLength(4);
+  });
+
+  it("handles exactly the limit", () => {
+    const blocks = makeBlocks(48);
+    const chunks = chunkBlocks(blocks, 48);
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0]).toHaveLength(48);
+  });
+
+  it("handles empty blocks array", () => {
+    const chunks = chunkBlocks([], 48);
+    expect(chunks).toHaveLength(0);
+  });
+});

--- a/tests/handlePROpened.test.ts
+++ b/tests/handlePROpened.test.ts
@@ -1,77 +1,278 @@
-import * as github from '@actions/github';
-import { handlePROpened } from '../src/handlePROpened';
-import { fetchAllCommits, Commit } from '../src/utils/fetchAllCommits';
+import * as github from "@actions/github";
+import {
+  handlePROpened,
+  filterMergeCommits,
+  categorizeCommits,
+} from "../src/handlePROpened";
+import { fetchAllCommits, Commit } from "../src/utils/fetchAllCommits";
 
-jest.mock('@actions/github');
-jest.mock('../src/utils/fetchAllCommits');
+jest.mock("@actions/github");
+jest.mock("../src/utils/fetchAllCommits");
 
 // Mock fetch globally
 global.fetch = jest.fn(async (url) => {
-  if (url === 'https://slack.com/api/chat.postMessage') {
-    return {
-      ok: true,
-      json: async () => ({ ok: true, ts: '12345' }),
-    } as Response;
+  if (url === "https://slack.com/api/chat.postMessage") {
+    return new Response(JSON.stringify({ ok: true, ts: "12345" }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
   }
-  throw new Error('Unexpected URL');
+  throw new Error("Unexpected URL");
 }) as jest.Mock;
 
-describe('handlePROpened', () => {
-  const slackToken = 'slack-token';
-  const slackChannelId = 'slack-channel-id';
-  const githubToken = 'github-token';
-  const initialMessageTemplate = 'PR opened: ${prUrl} - ${prTitle}';
+describe("filterMergeCommits", () => {
+  it('filters out "Merge branch" commits', () => {
+    const commits: Commit[] = [
+      {
+        sha: "1",
+        commit: {
+          message: "Merge branch 'main' into develop",
+          author: { name: "bot" },
+        },
+        author: null,
+      },
+      {
+        sha: "2",
+        commit: {
+          message: "fix(backend): Fix auth",
+          author: { name: "dev" },
+        },
+        author: { login: "dev" },
+      },
+    ];
+
+    const filtered = filterMergeCommits(commits);
+    expect(filtered).toHaveLength(1);
+    expect(filtered[0].sha).toBe("2");
+  });
+
+  it('filters out "Merge remote-tracking branch" commits', () => {
+    const commits: Commit[] = [
+      {
+        sha: "1",
+        commit: {
+          message: "Merge remote-tracking branch 'origin/main' into develop",
+          author: { name: "bot" },
+        },
+        author: null,
+      },
+    ];
+
+    const filtered = filterMergeCommits(commits);
+    expect(filtered).toHaveLength(0);
+  });
+
+  it('filters out "Merge pull request" commits', () => {
+    const commits: Commit[] = [
+      {
+        sha: "1",
+        commit: {
+          message: "Merge pull request #123 from user/branch",
+          author: { name: "bot" },
+        },
+        author: null,
+      },
+    ];
+
+    const filtered = filterMergeCommits(commits);
+    expect(filtered).toHaveLength(0);
+  });
+
+  it("keeps non-merge commits intact", () => {
+    const commits: Commit[] = [
+      {
+        sha: "1",
+        commit: {
+          message: "feat(frontend): Add button",
+          author: { name: "dev" },
+        },
+        author: { login: "dev" },
+      },
+      {
+        sha: "2",
+        commit: {
+          message: "chore(backend): Update deps",
+          author: { name: "dev2" },
+        },
+        author: { login: "dev2" },
+      },
+    ];
+
+    const filtered = filterMergeCommits(commits);
+    expect(filtered).toHaveLength(2);
+  });
+});
+
+describe("categorizeCommits", () => {
+  it("places multi-scope commit under first scope only", () => {
+    const commits: Commit[] = [
+      {
+        sha: "abc123",
+        commit: {
+          message: "chore(companion, bs, frontend): Update shared config",
+          author: { name: "dev" },
+        },
+        author: { login: "dev" },
+      },
+    ];
+
+    const result = categorizeCommits(commits, "owner", "repo");
+    // Only first scope gets the commit
+    expect(Object.keys(result)).toEqual(["companion"]);
+    expect(result["companion"]["chore"]).toHaveLength(1);
+    expect(result["companion"]["chore"][0].author).toBe("dev");
+  });
+
+  it("places multi-scope commit (no spaces) under first scope only", () => {
+    const commits: Commit[] = [
+      {
+        sha: "abc123",
+        commit: {
+          message: "fix(backend,frontend): Fix shared util",
+          author: { name: "dev" },
+        },
+        author: { login: "dev" },
+      },
+    ];
+
+    const result = categorizeCommits(commits, "owner", "repo");
+    expect(Object.keys(result)).toEqual(["backend"]);
+    expect(result["backend"]["fix"]).toHaveLength(1);
+  });
+
+  it('puts scopeless commits under "other"', () => {
+    const commits: Commit[] = [
+      {
+        sha: "abc123",
+        commit: {
+          message: "Update README",
+          author: { name: "dev" },
+        },
+        author: { login: "dev" },
+      },
+    ];
+
+    const result = categorizeCommits(commits, "owner", "repo");
+    expect(Object.keys(result)).toEqual(["other"]);
+  });
+
+  it("uses Slack user display when map is provided", () => {
+    const commits: Commit[] = [
+      {
+        sha: "abc123",
+        commit: {
+          message: "fix(backend): Fix auth",
+          author: { name: "dev" },
+        },
+        author: { login: "githubUser" },
+      },
+    ];
+
+    const result = categorizeCommits(commits, "owner", "repo", {
+      githubUser: "U12345",
+    });
+    expect(result["backend"]["fix"][0].text).toContain("<@U12345>");
+  });
+
+  it("places single-scope commit under its scope", () => {
+    const commits: Commit[] = [
+      {
+        sha: "abc123",
+        commit: {
+          message: "fix(backend): Fix auth",
+          author: { name: "dev" },
+        },
+        author: { login: "dev" },
+      },
+    ];
+
+    const result = categorizeCommits(commits, "owner", "repo");
+    expect(Object.keys(result)).toEqual(["backend"]);
+    expect(result["backend"]["fix"]).toHaveLength(1);
+  });
+
+  it("stores author for sorting", () => {
+    const commits: Commit[] = [
+      {
+        sha: "abc1",
+        commit: {
+          message: "fix(backend): Fix A",
+          author: { name: "zara" },
+        },
+        author: { login: "zara" },
+      },
+      {
+        sha: "abc2",
+        commit: {
+          message: "fix(backend): Fix B",
+          author: { name: "alice" },
+        },
+        author: { login: "alice" },
+      },
+    ];
+
+    const result = categorizeCommits(commits, "owner", "repo");
+    expect(result["backend"]["fix"][0].author).toBe("zara");
+    expect(result["backend"]["fix"][1].author).toBe("alice");
+  });
+});
+
+describe("handlePROpened", () => {
+  const slackToken = "slack-token";
+  const slackChannelId = "slack-channel-id";
+  const githubToken = "github-token";
+  const initialMessageTemplate = "PR opened: ${prUrl} - ${prTitle}";
   const commitListMessageTemplate =
-    'Commits:\n${commitListMessage}\nCompare changes: ${changelogUrl}';
-  const githubToSlackMap = { githubUser: 'slackUser' };
+    "Commits:\n${commitListMessage}\nCompare changes: ${changelogUrl}";
+  const githubToSlackMap = { githubUser: "slackUser" };
 
   const contextPayload = {
     payload: {
       pull_request: {
-        title: 'Test PR',
-        html_url: 'http://example.com',
-        head: { ref: 'feature-branch' },
-        base: { ref: 'main' },
+        title: "Test PR",
+        html_url: "http://example.com",
+        head: { ref: "feature-branch" },
+        base: { ref: "main" },
         number: 1,
-        body: 'PR body',
-        commits_url: 'http://api.github.com/commits',
+        body: "PR body",
+        commits_url: "http://api.github.com/commits",
       },
     },
     repo: {
-      owner: 'owner',
-      repo: 'repo',
+      owner: "owner",
+      repo: "repo",
     },
   };
 
   const mockCommitsData: Commit[] = [
     {
-      sha: 'commit1',
+      sha: "commit1",
       commit: {
-        message: 'Initial commit\nwith newline',
-        author: { name: 'author1' },
+        message: "Initial commit\nwith newline",
+        author: { name: "author1" },
       },
-      author: { login: 'githubUser' },
+      author: { login: "githubUser" },
     },
   ];
 
   beforeEach(() => {
     jest.clearAllMocks();
 
-    Object.defineProperty(github.context, 'payload', {
+    Object.defineProperty(github.context, "payload", {
       value: contextPayload.payload,
     });
 
-    Object.defineProperty(github.context, 'repo', {
+    Object.defineProperty(github.context, "repo", {
       value: contextPayload.repo,
     });
 
     (fetchAllCommits as jest.Mock).mockResolvedValue(mockCommitsData);
   });
 
-  it('sends initial Slack message and updates PR body', async () => {
+  it("sends initial Slack message and updates PR body", async () => {
     const initialSlackResponse = {
       ok: true,
-      ts: '12345',
+      ts: "12345",
     };
 
     global.fetch = jest
@@ -79,7 +280,7 @@ describe('handlePROpened', () => {
       .mockResolvedValueOnce(new Response(JSON.stringify(initialSlackResponse)))
       .mockResolvedValueOnce(new Response(JSON.stringify(mockCommitsData)))
       .mockResolvedValueOnce(
-        new Response(JSON.stringify(initialSlackResponse))
+        new Response(JSON.stringify(initialSlackResponse)),
       );
 
     const octokitMock = {
@@ -97,52 +298,52 @@ describe('handlePROpened', () => {
       githubToken,
       initialMessageTemplate,
       commitListMessageTemplate,
-      githubToSlackMap
+      githubToSlackMap,
     );
 
     expect(global.fetch).toHaveBeenCalledWith(
-      'https://slack.com/api/chat.postMessage',
+      "https://slack.com/api/chat.postMessage",
       expect.objectContaining({
         body: JSON.stringify({
           channel: slackChannelId,
-          text: 'PR opened: http://example.com - Test PR',
+          text: "PR opened: http://example.com - Test PR",
         }),
         headers: {
           Authorization: `Bearer ${slackToken}`,
-          'Content-Type': 'application/json',
+          "Content-Type": "application/json",
         },
-        method: 'POST',
-      })
+        method: "POST",
+      }),
     );
 
     expect(octokitMock.rest.pulls.update).toHaveBeenCalledWith(
       expect.objectContaining({
         pull_number: 1,
-        body: 'Slack message_ts: 12345\n\nPR body',
-      })
+        body: "Slack message_ts: 12345\n\nPR body",
+      }),
     );
 
     expect(global.fetch).toHaveBeenCalledWith(
-      'https://slack.com/api/chat.postMessage',
+      "https://slack.com/api/chat.postMessage",
       expect.objectContaining({
         body: JSON.stringify({
           channel: slackChannelId,
-          text: 'Commits:\n• <https://github.com/owner/repo/commit/commit1|Initial commit> by <@slackUser>\nCompare changes: https://github.com/owner/repo/compare/main...feature-branch',
-          thread_ts: '12345',
+          text: "Commits:\n• <https://github.com/owner/repo/commit/commit1|Initial commit> by <@slackUser>\nCompare changes: https://github.com/owner/repo/compare/main...feature-branch",
+          thread_ts: "12345",
         }),
         headers: {
           Authorization: `Bearer ${slackToken}`,
-          'Content-Type': 'application/json',
+          "Content-Type": "application/json",
         },
-        method: 'POST',
-      })
+        method: "POST",
+      }),
     );
   });
 
-  it('handles commit messages with newlines', async () => {
+  it("handles commit messages with newlines", async () => {
     const initialSlackResponse = {
       ok: true,
-      ts: '12345',
+      ts: "12345",
     };
 
     global.fetch = jest
@@ -150,7 +351,7 @@ describe('handlePROpened', () => {
       .mockResolvedValueOnce(new Response(JSON.stringify(initialSlackResponse)))
       .mockResolvedValueOnce(new Response(JSON.stringify(mockCommitsData)))
       .mockResolvedValueOnce(
-        new Response(JSON.stringify(initialSlackResponse))
+        new Response(JSON.stringify(initialSlackResponse)),
       );
 
     const octokitMock = {
@@ -168,28 +369,28 @@ describe('handlePROpened', () => {
       githubToken,
       initialMessageTemplate,
       commitListMessageTemplate,
-      githubToSlackMap
+      githubToSlackMap,
     );
 
     expect(global.fetch).toHaveBeenCalledWith(
-      'https://slack.com/api/chat.postMessage',
+      "https://slack.com/api/chat.postMessage",
       expect.objectContaining({
         body: JSON.stringify({
           channel: slackChannelId,
-          text: 'Commits:\n• <https://github.com/owner/repo/commit/commit1|Initial commit> by <@slackUser>\nCompare changes: https://github.com/owner/repo/compare/main...feature-branch',
-          thread_ts: '12345',
+          text: "Commits:\n• <https://github.com/owner/repo/commit/commit1|Initial commit> by <@slackUser>\nCompare changes: https://github.com/owner/repo/compare/main...feature-branch",
+          thread_ts: "12345",
         }),
         headers: {
           Authorization: `Bearer ${slackToken}`,
-          'Content-Type': 'application/json',
+          "Content-Type": "application/json",
         },
-        method: 'POST',
-      })
+        method: "POST",
+      }),
     );
   });
 
-  it('throws an error if no pull request is found', async () => {
-    Object.defineProperty(github.context, 'payload', {
+  it("throws an error if no pull request is found", async () => {
+    Object.defineProperty(github.context, "payload", {
       value: {},
       writable: true,
     });
@@ -201,19 +402,19 @@ describe('handlePROpened', () => {
         githubToken,
         initialMessageTemplate,
         commitListMessageTemplate,
-        githubToSlackMap
-      )
-    ).rejects.toThrow('No pull request found');
+        githubToSlackMap,
+      ),
+    ).rejects.toThrow("No pull request found");
   });
 
-  it('throws an error if initial Slack message fails', async () => {
+  it("throws an error if initial Slack message fails", async () => {
     const initialSlackResponse = {
       ok: false,
     };
     global.fetch = jest
       .fn()
       .mockResolvedValueOnce(
-        new Response(JSON.stringify(initialSlackResponse))
+        new Response(JSON.stringify(initialSlackResponse)),
       );
 
     await expect(
@@ -223,8 +424,231 @@ describe('handlePROpened', () => {
         githubToken,
         initialMessageTemplate,
         commitListMessageTemplate,
-        githubToSlackMap
-      )
-    ).rejects.toThrow('Failed to send initial Slack message');
+        githubToSlackMap,
+      ),
+    ).rejects.toThrow("Failed to send initial Slack message");
+  });
+
+  it("filters merge commits and posts remaining", async () => {
+    const commitsWithMerge: Commit[] = [
+      {
+        sha: "merge1",
+        commit: {
+          message: "Merge branch 'main' into develop",
+          author: { name: "bot" },
+        },
+        author: null,
+      },
+      {
+        sha: "real1",
+        commit: {
+          message: "fix(backend): Fix auth",
+          author: { name: "dev" },
+        },
+        author: { login: "githubUser" },
+      },
+    ];
+    (fetchAllCommits as jest.Mock).mockResolvedValue(commitsWithMerge);
+
+    global.fetch = jest.fn().mockImplementation(
+      async () =>
+        new Response(JSON.stringify({ ok: true, ts: "12345" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+
+    const octokitMock = {
+      rest: { pulls: { update: jest.fn() } },
+    };
+    (github.getOctokit as jest.Mock).mockReturnValue(octokitMock);
+
+    await handlePROpened(
+      slackToken,
+      slackChannelId,
+      githubToken,
+      initialMessageTemplate,
+      commitListMessageTemplate,
+      githubToSlackMap,
+    );
+
+    // The commit list message should only contain the fix commit, not the merge
+    const fetchCalls = (global.fetch as jest.Mock).mock.calls;
+    const commitListCall = fetchCalls.find((call: [string, RequestInit]) => {
+      const body = JSON.parse(call[1].body as string);
+      return body.thread_ts === "12345" && body.text;
+    });
+    expect(commitListCall).toBeDefined();
+    const body = JSON.parse(commitListCall![1].body as string);
+    expect(body.text).toContain("fix(backend): Fix auth");
+    expect(body.text).not.toContain("Merge branch");
+  });
+
+  it('posts "No conventional commits" when all commits are merge commits', async () => {
+    const onlyMergeCommits: Commit[] = [
+      {
+        sha: "merge1",
+        commit: {
+          message: "Merge branch 'main' into develop",
+          author: { name: "bot" },
+        },
+        author: null,
+      },
+    ];
+    (fetchAllCommits as jest.Mock).mockResolvedValue(onlyMergeCommits);
+
+    global.fetch = jest.fn().mockImplementation(
+      async () =>
+        new Response(JSON.stringify({ ok: true, ts: "12345" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+
+    const octokitMock = {
+      rest: { pulls: { update: jest.fn() } },
+    };
+    (github.getOctokit as jest.Mock).mockReturnValue(octokitMock);
+
+    await handlePROpened(
+      slackToken,
+      slackChannelId,
+      githubToken,
+      initialMessageTemplate,
+      commitListMessageTemplate,
+      githubToSlackMap,
+    );
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "https://slack.com/api/chat.postMessage",
+      expect.objectContaining({
+        body: JSON.stringify({
+          channel: slackChannelId,
+          text: "No conventional commits to display.",
+          thread_ts: "12345",
+        }),
+      }),
+    );
+  });
+
+  it("sends Block Kit blocks when sortCommits is true", async () => {
+    const sortedCommits: Commit[] = [
+      {
+        sha: "abc1",
+        commit: {
+          message: "fix(backend): Fix auth",
+          author: { name: "dev" },
+        },
+        author: { login: "githubUser" },
+      },
+      {
+        sha: "abc2",
+        commit: {
+          message: "chore(frontend): Update deps",
+          author: { name: "dev2" },
+        },
+        author: { login: "dev2" },
+      },
+    ];
+    (fetchAllCommits as jest.Mock).mockResolvedValue(sortedCommits);
+
+    global.fetch = jest.fn().mockImplementation(
+      async () =>
+        new Response(JSON.stringify({ ok: true, ts: "12345" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+
+    const octokitMock = {
+      rest: { pulls: { update: jest.fn() } },
+    };
+    (github.getOctokit as jest.Mock).mockReturnValue(octokitMock);
+
+    await handlePROpened(
+      slackToken,
+      slackChannelId,
+      githubToken,
+      initialMessageTemplate,
+      commitListMessageTemplate,
+      githubToSlackMap,
+      true, // sortCommits
+    );
+
+    // Find the Block Kit message call (has `blocks` property)
+    const fetchCalls = (global.fetch as jest.Mock).mock.calls;
+    const blockKitCall = fetchCalls.find((call: [string, RequestInit]) => {
+      const body = JSON.parse(call[1].body as string);
+      return body.blocks !== undefined;
+    });
+    expect(blockKitCall).toBeDefined();
+    const body = JSON.parse(blockKitCall![1].body as string);
+    expect(body.blocks).toBeDefined();
+    expect(body.thread_ts).toBe("12345");
+
+    // Verify block structure: backend header comes first (alphabetical)
+    const headerBlocks = body.blocks.filter(
+      (b: { type: string }) => b.type === "header",
+    );
+    expect(headerBlocks[0].text.text).toBe("Backend");
+    expect(headerBlocks[1].text.text).toBe("Frontend");
+
+    // Verify fallback text exists
+    expect(body.text).toBeDefined();
+    expect(body.text).toContain("Backend");
+    expect(body.text).toContain("Frontend");
+  });
+
+  it("handles multi-scope commits with spaces in sortCommits mode", async () => {
+    const multiScopeCommits: Commit[] = [
+      {
+        sha: "abc1",
+        commit: {
+          message: "chore(companion, bs, frontend): Update shared config",
+          author: { name: "dev" },
+        },
+        author: { login: "dev" },
+      },
+    ];
+    (fetchAllCommits as jest.Mock).mockResolvedValue(multiScopeCommits);
+
+    global.fetch = jest.fn().mockImplementation(
+      async () =>
+        new Response(JSON.stringify({ ok: true, ts: "12345" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+
+    const octokitMock = {
+      rest: { pulls: { update: jest.fn() } },
+    };
+    (github.getOctokit as jest.Mock).mockReturnValue(octokitMock);
+
+    await handlePROpened(
+      slackToken,
+      slackChannelId,
+      githubToken,
+      initialMessageTemplate,
+      commitListMessageTemplate,
+      undefined,
+      true, // sortCommits
+    );
+
+    // Find the Block Kit message call
+    const fetchCalls = (global.fetch as jest.Mock).mock.calls;
+    const blockKitCall = fetchCalls.find((call: [string, RequestInit]) => {
+      const body = JSON.parse(call[1].body as string);
+      return body.blocks !== undefined;
+    });
+    expect(blockKitCall).toBeDefined();
+    const body = JSON.parse(blockKitCall![1].body as string);
+
+    // Should have header only for primary scope: companion (first listed)
+    const headerBlocks = body.blocks.filter(
+      (b: { type: string }) => b.type === "header",
+    );
+    expect(headerBlocks).toHaveLength(1);
+    expect(headerBlocks[0].text.text).toBe("Companion");
   });
 });


### PR DESCRIPTION
Slack message_ts: 1774550949.224129

## Summary
- **Fix multi-scope regex**: Changed `/^\w+\(([\w,]+)\):/` to `/^\w+\(([\w,\s]+)\):/` so commits like `chore(companion, bs, frontend):` are correctly parsed instead of falling into "other"
- **Place multi-scope commits under primary scope**: Multi-scope commits (e.g. `chore(companion, bs, frontend):`) are now placed under the first (primary) scope only, instead of duplicating across all scopes
- **Filter merge commits**: Removes `Merge branch '...'`, `Merge remote-tracking branch '...'`, and `Merge pull request #...` from the initial commit list (does not affect `synchronize` event notifications)
- **Upgrade to Slack Block Kit**: When `sort-commits=true`, sends structured Block Kit messages with headers per scope, type groupings, dividers, and changelog link. Includes chunking for Slack's 50-block limit. Falls back to plain text when `sort-commits=false` (fully backward compatible)
- **Handle empty commits**: Posts "No conventional commits to display." when all commits are filtered out

## Test plan
- [x] All 33 tests pass (`npm test`)
- [x] `npm run build` generates `dist/index.js` successfully
- [ ] Preview Block Kit output in [Slack Block Kit Builder](https://app.slack.com/block-kit-builder)
- [ ] End-to-end test with a release PR referencing the updated action